### PR TITLE
simplification

### DIFF
--- a/matGeom/polygons2d/rectAsPolygon.m
+++ b/matGeom/polygons2d/rectAsPolygon.m
@@ -1,4 +1,4 @@
-function varargout = rectAsPolygon(rect)
+function [tx ty] = rectAsPolygon (rect)
 %RECTASPOLYGON Convert a (centered) rectangle into a series of points
 %
 %   P = rectAsPolygon(RECT);
@@ -16,32 +16,22 @@ function varargout = rectAsPolygon(rect)
 %
 
 %   HISTORY
+%   2016: Simplify by JuanPi Carbajal
 
 theta = 0;
-x = rect(1);
-y = rect(2);
-w = rect(3)/2;  % easier to compute with w and h divided by 2
-h = rect(4)/2;
-if length(rect)>4
-    theta = rect(5);
+x     = rect(1);
+y     = rect(2);
+w     = rect(3) / 2;  # easier to compute with w and h divided by 2
+h     = rect(4) / 2;
+if length (rect) > 4
+  theta = rect(5);
 end
 
-cot = cos(theta);
-sit = sin(theta);
+v = [cos(theta); sin(theta)];
+M = bsxfun (@times, [-1 1; 1 1; 1 -1; -1 -1], [w h]);
+tx  = x + M * v;
+ty  = y + M(4:-1:1,[2 1]) * v;
 
-tx(1) = x - w*cot + h*sit;
-ty(1) = y - w*sit - h*cot;
-tx(2) = x + w*cot + h*sit;
-ty(2) = y + w*sit - h*cot;
-tx(3) = x + w*cot - h*sit;
-ty(3) = y + w*sit + h*cot;
-tx(4) = x - w*cot - h*sit;
-ty(4) = y - w*sit + h*cot;
-
-
-if nargout==1
-    varargout{1}=[tx' ty'];
-elseif nargout==2
-    varargout{1}=tx';
-    varargout{2}=ty';    
+if nargout == 1
+  tx = [tx ty];
 end


### PR DESCRIPTION
The function is simplified to have fewer lines of code.
varargin and vargout were removed, since introduce a overhead and they should be used only if really needed.
Also, I noticed that many draw\* functions use recursion. You should try to avoid this, specially for parsing options. This can be solved with loops or structures. Will improve them when I have some time.
