### PR TITLE
Fixing the value returned by the example

### DIFF
--- a/matGeom/geom3d/createRotation3dLineAngle.m
+++ b/matGeom/geom3d/createRotation3dLineAngle.m
@@ -12,7 +12,7 @@ function mat = createRotation3dLineAngle(line, theta)
 %     [axis angle2] = rotation3dAxisAndAngle(rot);
 %     angle2
 %     angle2 =
-%           1.015
+%           1.0472
 %
 %   See also
 %   transforms3d, rotation3dAxisAndAngle, rotation3dToEulerAngles,


### PR DESCRIPTION
Minor fix in the embedded example. The initial angle in the example is pi/3 so the return value will be 1.0472 rather than 1.015 (I don't know where that value came from).
