### PR TITLE
Generalize intersectLineCircle for several pairs

### DIFF
--- a/matGeom/geom2d/intersectLineCircle.m
+++ b/matGeom/geom2d/intersectLineCircle.m
@@ -45,7 +45,7 @@ function points = intersectLineCircle(line, circle)
 %   15/04/2017: improved code by JuanPi Carbajal <ajuanpi+dev@gmail.com>
 
 n = size (line, 1);
-if (n != size (circle, 1))
+if n ~= size (circle, 1)
   error ('matGeom:invalid-input-arg', 'Function takes same number of lines and circles.');
 endif
 


### PR DESCRIPTION
A re-write of the function to be able to process several lines and circles.

Note that output of the original function does not conserve the shape when there is a single intersection point. This has been fixed in this version the output is always 2-by-2 for each line-circle pair, as the help text explains.

I have also replaced the use of NaN (which is used to separate polygons) with NA, which is the recommended value when there is no answer (NaN implies that there is an answer but can't be represented in finite precision float point numbers).

I also removed the use of a tolerance, since the needed check is for non-negativity of 'delta', and always two intersection points are returned (to keep size of output consistent with help text).