### PR TITLE
Fixed drawShape dependency on deprecated functions 

### DIFF
--- a/matGeom/geom2d/drawShape.m
+++ b/matGeom/geom2d/drawShape.m
@@ -53,9 +53,9 @@ end
 shape = cell(1,length(type));
 for i = 1:length(type)    
     if strcmpi(type{i}, 'circle')
-        shape{i} = circleAsPolygon(param{i}, 128);
+        shape{i} = circleToPolygon(param{i}, 128);
     elseif strcmpi(type{i}, 'rect')
-        shape{i} = rectAsPolygon(param{i});
+        shape{i} = rectToPolygon(param{i});
     elseif strcmpi(type{i}, 'polygon')
         shape{i} = param{i};        
     end


### PR DESCRIPTION
drawShape still depends on: circleAsPolygon and rectAsPolygon
changed to newer versions: circleToPolygon and rectToPolygon