### PR TITLE
drawPlane3d: doc, signature

### DIFF
--- a/matGeom/geom2d/drawPoint.m
+++ b/matGeom/geom2d/drawPoint.m
@@ -87,12 +87,16 @@ if length(varargin) > 1
     if tf
         error ('Points cannot be draw with lines, use plot or drawPolygon instead');
     end
-    h = plot (ax, px, py, 'marker', 'o', 'linestyle', 'none', varargin{:});
+    htmp = plot (ax, px, py, 'marker', 'o', 'linestyle', 'none', varargin{:});
     
 elseif length(varargin) == 1
     % use the specified single option (for example: 'b.', or 'k+')
-    h = plot (ax, px, py, varargin{1});
+    htmp = plot (ax, px, py, varargin{1});
 else
     % use a default marker
-    h = plot (ax, px, py, 'o');
+    htmp = plot (ax, px, py, 'o');
+end
+
+if nargout > 0
+    h = htmp;
 end

--- a/matGeom/geom3d/drawPlane3d.m
+++ b/matGeom/geom3d/drawPlane3d.m
@@ -1,21 +1,19 @@
-function varargout = drawPlane3d(plane, varargin)
-%DRAWPLANE3D Draw a plane clipped by the current axes
+function h = drawPlane3d(plane, varargin)
+%DRAWPLANE3D Draw a plane clipped in the current axes
 %
 %   drawPlane3d(PLANE) draws a plane of the format:
 %       [x0 y0 z0  dx1 dy1 dz1  dx2 dy2 dz2]
 %
 %   drawPlane3d(...,'PropertyName',PropertyValue,...) sets the value of the
 %   specified patch property. Multiple property values can be set with
-%   a single statement.
+%   a single statement. See function patch for details.
 %
 %   drawPlane3d(AX,...) plots into AX instead of GCA.
 %
 %   H = drawPlane3d(...) returns a handle H to the patch object.
 %
-%   See also
-%   planes3d, createPlane
-%
 %   Example
+%
 %     p0 = [1 2 3];
 %     v1 = [1 0 1];
 %     v2 = [0 -1 1];
@@ -26,6 +24,9 @@ function varargout = drawPlane3d(plane, varargin)
 %     drawLine3d([p0 v2])
 %     set(gcf, 'renderer', 'zbuffer');
 %
+%   See also
+%   planes3d, createPlane, patch
+
 % ------
 % Author: David Legland
 % e-mail: david.legland@inra.fr
@@ -92,7 +93,7 @@ points = [...
     piZ00;piZ01;piZ10;piZ11;];
 
 % check validity: keep only points inside window (with tolerance)
-ac = 1e-14;
+ac = sqrt (eps);
 ivx = points(:,1) >= xmin-ac & points(:,1) <= xmax+ac;
 ivy = points(:,2) >= ymin-ac & points(:,2) <= ymax+ac;
 ivz = points(:,3) >= zmin-ac & points(:,3) <= zmax+ac;
@@ -102,10 +103,7 @@ pts = unique(points(valid, :), 'rows');
 % If there is no intersection point, escape.
 if size(pts, 1) < 3
     disp('plane is outside the drawing window');
-    if nargout > 0
-        h=nan;
-        varargout = {h};
-    end
+    h = [];
     return;
 end
 
@@ -126,8 +124,3 @@ h = patch(hAx, ...
     'XData', pts(ind,1), ...
     'YData', pts(ind,2), ...
     'ZData', pts(ind,3), varargin{:});
-
-% return handle to plane if needed
-if nargout > 0
-    varargout = {h};
-end

--- a/matGeom/geom3d/drawPlane3d.m
+++ b/matGeom/geom3d/drawPlane3d.m
@@ -103,7 +103,9 @@ pts = unique(points(valid, :), 'rows');
 % If there is no intersection point, escape.
 if size(pts, 1) < 3
     disp('plane is outside the drawing window');
-    h = [];
+    if nargout > 0
+        h = [];
+    end
     return;
 end
 
@@ -127,6 +129,6 @@ htmp = patch(hAx, ...
 
 % Do not return axis if not requested
 % avoids output when called without semicolon
-if (nargout > 0)
+if nargout > 0
     h = htmp;
-endif
+end

--- a/matGeom/geom3d/drawPlane3d.m
+++ b/matGeom/geom3d/drawPlane3d.m
@@ -129,4 +129,4 @@ htmp = patch(hAx, ...
 % avoids output when called without semicolon
 if (nargout > 0)
     h = htmp;
-endif
+end

--- a/matGeom/geom3d/drawPlane3d.m
+++ b/matGeom/geom3d/drawPlane3d.m
@@ -120,7 +120,13 @@ ind = convhull(u1, u2);
 ind = ind(1:end-1);
 
 % draw the patch
-h = patch(hAx, ...
+htmp = patch(hAx, ...
     'XData', pts(ind,1), ...
     'YData', pts(ind,2), ...
     'ZData', pts(ind,3), varargin{:});
+
+% Do not return axis if not requested
+% avoids output when called without semicolon
+if (nargout > 0)
+    h = htmp;
+endif


### PR DESCRIPTION
* Small improvement in the docstring to point to the function patch

* Do not user varargout when there are no variable output arguments,
  the function now returns the handle to the object

* The default behavior for non-created graphics objects is to return empty.
  The handle to the patch is now empty if the plane is outside of the axes.

* use sqrt(eps) as tolerance. Does matlab accept default arguments? if yes I would 
  change the signature to
  h = drawPlane3d (plane, tol = sqrt(eps), varargin)
