### PR TITLE
fix meshFaceAreas.m x2 typo

### DIFF
--- a/matGeom/meshes3d/meshFaceAreas.m
+++ b/matGeom/meshes3d/meshFaceAreas.m
@@ -35,7 +35,7 @@ if isnumeric(faces)
             v1 = vertices(faces(:,1), :);
             v12 = vertices(faces(:,2), :) - v1;
             v13 = vertices(faces(:,3), :) - v1;
-            areas = vectorNorm3d(crossProduct3d(v12, v13));
+            areas = vectorNorm3d(crossProduct3d(v12, v13))/2;
             
         else
             % for quad (or larger) meshes, use slower but more precise method


### PR DESCRIPTION
meshFaceAreas.m produces areas for triangular meshes which are double the true value due to a missing "/2".

To reproduce:
````
% 3-4-5 triangle
v = [0,0,0;
     3,0,0;
     0,4,0];
f = [1,2,3];
tri_area = meshFaceAreas( v, f )
% expected: 6, actual: 12

% 3x4 rectangle
v = [0,0,0;
     3,0,0;
     3,4,0;
     0,4,0];
f = [1,2,3,4];
rect_area = meshFaceAreas( v, f )
% expected: 12, actual: 12
````