### PR TITLE
doc: unify format of Contents.m files

### DIFF
--- a/matGeom/deprecated/geom3d/createEulerAnglesRotation.m
+++ b/matGeom/deprecated/geom3d/createEulerAnglesRotation.m
@@ -4,7 +4,7 @@ function mat = createEulerAnglesRotation(phi, theta, psi)
 %   ROT = createEulerAnglesRotation(PHI, THETA, PSI)
 %   Create a rotation matrix from the 3 euler angles PHI THETA and PSI,
 %   in radians, using the 'XYZ' convention. These angles correspond to the
-%   "Roll-Pitch-Yaw" convention, also known as "Tait–Bryan angles".
+%   "Roll-Pitch-Yaw" convention, also known as "TaitÂ–Bryan angles".
 %   PHI:    rotation angle around X-axis, in radians, corresponding to the
 %       'Roll'. PHI is between -pi and +pi. 
 %   THETA:  rotation angle around Y-axis, in radians, corresponding to the

--- a/matGeom/geom2d/Contents.m
+++ b/matGeom/geom2d/Contents.m
@@ -199,8 +199,7 @@
 % Project homepage: http://github.com/mattools/matGeom
 % http://www.pfl-cepia.inra.fr/index.php?page=geom2d
 
-help('Contents');
-
+help(mfilename);
 
 %%   Deprecated functions
 %   normalize                - Normalize a vector.

--- a/matGeom/geom3d/Contents.m
+++ b/matGeom/geom3d/Contents.m
@@ -217,7 +217,7 @@
 %   * Songbai Ji enhanced file intersectPlaneLine (6/23/2006).
 %   * several functions contributed by oqilipo
 %
-
+%
 % ------
 % Author: David Legland
 % e-mail: david.legland@inra.fr
@@ -225,6 +225,8 @@
 % Homepage: http://github.com/mattools/matGeom
 % http://www.pfl-cepia.inra.fr/index.php?page=geom3d
 % Copyright 2005 INRA
+
+help(mfilename);
 
 % In development:
 %   clipPolygon3dHP             - clip a 3D polygon with Half-space.

--- a/matGeom/geom3d/drawCircle3d.m
+++ b/matGeom/geom3d/drawCircle3d.m
@@ -203,7 +203,7 @@ else
 end
 
 % circle parametrisation (by using N=60, some vertices are located at
-% special angles like 45°, 30°...)
+% special angles like 45Â°, 30Â°...)
 Nt  = 60;
 t   = linspace(0, 2*pi, Nt+1);
 

--- a/matGeom/geom3d/eulerAnglesToRotation3d.m
+++ b/matGeom/geom3d/eulerAnglesToRotation3d.m
@@ -14,7 +14,7 @@ function mat = eulerAnglesToRotation3d(phi, theta, psi, varargin)
 %   PSI:    rotation angle around X-axis, in degrees, corresponding to the
 %       'Roll'. PSI is between -180 and +180.
 %   These angles correspond to the "Yaw-Pitch-Roll" convention, also known
-%   as "Tait–Bryan angles".
+%   as "Tait-Bryan angles".
 %
 %   The resulting rotation is equivalent to a rotation around X-axis by an
 %   angle PSI, followed by a rotation around the Y-axis by an angle THETA,

--- a/matGeom/geom3d/revolutionSurface.m
+++ b/matGeom/geom3d/revolutionSurface.m
@@ -63,8 +63,8 @@ function varargout = revolutionSurface(varargin)
 % default values
 
 % use revolution using the full unit circle, decomposed into 24 angular
-% segments (thus, some vertices correspond to particular angles 30°,
-% 45°...)
+% segments (thus, some vertices correspond to particular angles 30Â°,
+% 45Â°...)
 theta = linspace(0, 2*pi, 25);
 
 % use planar vertical axis as default revolution axis

--- a/matGeom/graphs/Contents.m
+++ b/matGeom/graphs/Contents.m
@@ -126,6 +126,8 @@
 % created the  07/11/2005.
 % Copyright INRA - Cepia Software Platform.
 
+help(mfilename);
+
   
 % HISTORY
 % 25/07/2007 remove old functions

--- a/matGeom/graphs/clipGraph.m
+++ b/matGeom/graphs/clipGraph.m
@@ -124,7 +124,7 @@ for e = 1:size(edges, 1)
     edge = clipEdge(edge, [box(1) box(2); box(3) box(4)]);
     
     % display debug info
-    %disp(sprintf('clip edge n°%2d, from %2d to %2d', e, edges(e,1), edges(e,2)));
+    %disp(sprintf('clip edge nÂ°%2d, from %2d to %2d', e, edges(e,1), edges(e,2)));
     
     % Node for first vertex
     if ~in1

--- a/matGeom/meshes3d/Contents.m
+++ b/matGeom/meshes3d/Contents.m
@@ -140,6 +140,7 @@
 % http://www.pfl-cepia.inra.fr/index.php?page=geom3d
 % Copyright 2005 INRA - CEPIA Nantes - MIAJ (Jouy-en-Josas).
 
+help(mfilename);
 
 % Deprecated:
 

--- a/matGeom/meshes3d/createDurerPolyhedron.m
+++ b/matGeom/meshes3d/createDurerPolyhedron.m
@@ -35,7 +35,7 @@ function varargout = createDurerPolyhedron(varargin)
 %
 %   References
 %   http://mathworld.wolfram.com/DuerersSolid.html
-%   http://en.wikipedia.org/wiki/Dürer_graph
+%   http://en.wikipedia.org/wiki/DÃ¼rer_graph
 
 % ------
 % Author: David Legland

--- a/matGeom/meshes3d/createOctahedron.m
+++ b/matGeom/meshes3d/createOctahedron.m
@@ -15,9 +15,9 @@ function varargout = createOctahedron()
 %   and 'faces'.
 %
 %   Vertices are located on grid vertices:
-%    ( ±1,  0,  0 )
-%    (  0, ±1,  0 )
-%    (  0,  0, ±1 )
+%    ( Â±1,  0,  0 )
+%    (  0, Â±1,  0 )
+%    (  0,  0, Â±1 )
 %
 %   Edge length of returned octahedron is sqrt(2).
 %   Surface area of octahedron is 2*sqrt(3)*a^2, approximately 6.9282 in

--- a/matGeom/meshes3d/private/progressbar.m
+++ b/matGeom/meshes3d/private/progressbar.m
@@ -8,7 +8,7 @@ function progressbar(n,N,w)
 % n should start at 1.
 % w is the width of the bar (default w=20).
 %
-%   Copyright (c) Gabriel Peyré 2006
+%   Copyright (c) Gabriel Peyr√© 2006
 
 if nargin<3
     w = 20;

--- a/matGeom/polygons2d/Contents.m
+++ b/matGeom/polygons2d/Contents.m
@@ -163,7 +163,7 @@
 % http://www.pfl-cepia.inra.fr/index.php?page=geom2d
 % Copyright INRA - Cepia Software Platform.
 
-help('Contents');
+help(mfilename);
 
 %% Deprecated
 %   polygonInertiaEllipse     - Compute ellipse with same inertia moments as polygon.

--- a/matGeom/polynomialCurves2d/Contents.m
+++ b/matGeom/polynomialCurves2d/Contents.m
@@ -58,8 +58,7 @@
 % http://www.pfl-cepia.inra.fr/index.php?page=geom2d
 % Copyright INRA - Cepia Software Platform.
 
-help('Contents');
-
+help(mfilename);
 
 %%   Deprecated functions:
 


### PR DESCRIPTION
Make all Contents file look the same.

Also several files used non-ascii or non-utf8 encodings

```
$ find . -type f -name "*.m" -exec sh -c 'cs=$(file -i "$0" | cut -d"=" -f2); if [ $cs != "us-ascii" ]; then echo $0" "$cs; fi' {} \;
./geom3d/drawCircle3d.m iso-8859-1
./geom3d/revolutionSurface.m iso-8859-1
./deprecated/geom3d/createEulerAnglesRotation.m unknown-8bit
./meshes3d/private/progressbar.m unknown-8bit
./meshes3d/createDurerPolyhedron.m iso-8859-1
./meshes3d/createOctahedron.m iso-8859-1
./graphs/clipGraph.m iso-8859-1
```
I have fixed them using

`$ find . -type f -name "*.m" -exec sh -c 'cs=$(file -i "$0" | cut -d"=" -f2); if [ $cs != "us-ascii" ]; then iconv -f ISO-8859-1 -t UTF-8//TRANSLIT $0 > $0"_t"; fi' {} \;
`
then I manually checked their contents and overwrote the originals with the *.m_t files generated by that command