### PR TITLE
Bugfix for distancePointMesh

### DIFF
--- a/matGeom/meshes3d/distancePointMesh.m
+++ b/matGeom/meshes3d/distancePointMesh.m
@@ -278,9 +278,9 @@ for i = 1:nPoints
     s(inds2) = 0;
     bool3 = e(inds2) >= 0;
     t(inds2(bool3)) = 0;
-    bool3 = e(inds2) < 0 & c(inds2) <= e(inds2);
+    bool3 = e(inds2) < 0 & c(inds2) <= -e(inds2);
     t(inds2(bool3)) = 1;
-    bool3 = e(inds2) < 0 & c(inds2) > e(inds2);
+    bool3 = e(inds2) < 0 & c(inds2) > -e(inds2);
     inds3 = inds2(bool3);
     t(inds3) = -e(inds3) ./ c(inds3);
     

--- a/tests/meshes3d/test_distancePointMesh.m
+++ b/tests/meshes3d/test_distancePointMesh.m
@@ -74,3 +74,83 @@ f = [1 2 3];
 point111 = [11 1 0];
 d = distancePointMesh(point111, v, f, 'algorithm', 'vectorized');
 testCase.assertEqual(sqrt(2), d, 0.0001);
+
+function testSingleTriangleAllSubregions(testCase)
+% The algorithm described in "David Eberly, 'Distance Between Point and 
+% Triangle in 3D', Geometric Tools, LLC, (1999)" splits the plane of the
+% triangle into region 0 to 6. The regions here are not numbered as in the
+% original paper of D. Eberly but as in distancePointTrimesh_vectorized.
+%
+%        /\ t
+%        |
+%   \ R5 |
+%    \   |
+%     \  |
+%      \ |
+%       \| P3
+%        *
+%        |\
+%        | \
+%   R1   |  \   R4
+%        |   \
+%        | R0 \ 
+%        |     \ 
+%        | P1   \ P2
+%  ------*-------*------> s
+%        |        \   
+%   R3   |   R2    \   R6 
+%
+% In the code the regions split into subregions. The regions over the
+% vertices into 5, some of which only occur if the vertex has an abuse
+% angle. The regions over edges split into 3 subregions, some of which
+% only occur if the neighbouring vertices have acute angles.
+% The following code uses triangle and one set of test points and
+% switches the vertex numbers, so that every subcase is tested.
+
+v = [36 20 10; 40 20 10; 30 30 10];
+
+% The regions for the testPoints in the comment apply for faces = [1 2 3].
+% For faces = [2 3 1] R3 becomes R5 and R4 becomes R2.
+% For faces = [3 1 2] R3 becomes R6 and R4 becomes R1.
+% Also the terms for the subcases change, but still all subcases are
+% tested.
+testPoints = [36 22 10; %R0
+    42 5 10; %R3 (d<0 & a<=d)
+    38 5 10; %R3 (d<0 & a>d)
+    30 5 10; %R3 (d>=0 & e>=0)
+    5 18 10; %R3 (d>=0 & c<=-e)
+    13 13 10; %R3 (c>-e & e<0)
+    30 40 10; %R4 ((c+e)-(b+d)<=0)
+    50 25 10; %R4 ((c+e)-(b+d)>=a-2*b+c)
+    40 30 10]; %R4 ((c+e)-(b+d)>0 & (c+e)-(b+d)<a-2*b+c)
+
+projResults = [36 22 10;
+    40 20 10;
+    38 20 10;
+    36 20 10;
+    30 30 10;
+    33 25 10;
+    30 30 10;
+    40 20 10;
+    35 25 10];
+
+f = [1 2 3];
+
+[dist_s, proj_s] = distancePointMesh(testPoints, v, f, 'algorithm', 'sequential');
+testCase.assertEqual(proj_s, projResults, 'AbsTol', 1e-6)
+[dist_v, proj_v] = distancePointMesh(testPoints, v, f, 'algorithm', 'vectorized');
+testCase.assertEqual(proj_v, projResults, 'AbsTol', 1e-6)
+
+f = [2 3 1];
+
+[dist_s, proj_s] = distancePointMesh(testPoints, v, f, 'algorithm', 'sequential');
+testCase.assertEqual(proj_s, projResults, 'AbsTol', 1e-6)
+[dist_v, proj_v] = distancePointMesh(testPoints, v, f, 'algorithm', 'vectorized');
+testCase.assertEqual(proj_v, projResults, 'AbsTol', 1e-6)
+
+f = [3 1 2];
+
+[dist_s, proj_s] = distancePointMesh(testPoints, v, f, 'algorithm', 'sequential');
+testCase.assertEqual(proj_s, projResults, 'AbsTol', 1e-6)
+[dist_v, proj_v] = distancePointMesh(testPoints, v, f, 'algorithm', 'vectorized');
+testCase.assertEqual(proj_v, projResults, 'AbsTol', 1e-6)


### PR DESCRIPTION
This pull request fixes a small bug in distancePointMesh (vectorized algorithm) if the nearest point on the triangle is in a sub case of region 3. Then it enhances distancePointMesh to handle multiple query points in one call for the sequential algorithm (this already worked for the vectorized case). And it adds a test which would have found the issue.
