### PR TITLE
use current axes handle if no axes is provided

### DIFF
--- a/matGeom/geom3d/drawPolyline3d.m
+++ b/matGeom/geom3d/drawPolyline3d.m
@@ -42,10 +42,12 @@ function varargout = drawPolyline3d(varargin)
 
 
 %% Process input arguments
-hAx = gca;
+
 if isAxisHandle(varargin{1})
     hAx = varargin{1};
     varargin(1) = [];
+else
+    hAx = gca;
 end
 
 % check case we want to draw several curves, stored in a cell array


### PR DESCRIPTION
This solved the issue when drawPolyline3d is used with the app designer. The function will create a new empty figure even if the axes handle is provided in the first input of the function. To solve this problem, check if the first input is the axes handle, if not create a new figure. This also seems to be true for other functions in matGeom, however, this one is tested.