### PR TITLE
Drop polynomialCurves2d from the Contents file

### DIFF
--- a/matGeom/Contents.m
+++ b/matGeom/Contents.m
@@ -9,7 +9,6 @@
 %   geom2d              - General function in euclidean plane
 %   polygons2d          - Functions operating on point lists 
 %   graphs              - Manipulation of geometric graphs
-%   polynomialCurves2d  - Representation of smooth polynomial curves
 %   geom3d              - General function in 3D euclidean space
 %   meshes3d            - Manipulation of 3D surfacic meshes
 %


### PR DESCRIPTION
The polynomialCurves2d module was removed in commit f79f6fd. Let'us keep the Contents.m file in synch.